### PR TITLE
Fix failing symbol IonHashTests

### DIFF
--- a/Amazon.IonHashDotnet.Tests/ion_hash_tests.ion
+++ b/Amazon.IonHashDotnet.Tests/ion_hash_tests.ion
@@ -337,10 +337,8 @@ timestampDistinct03::{
 // /timestamps
 
 // symbols
-/*
 { ion:$0,            expect:{ identity:(update::(0x0b) update::(0x71) update::(0x0e)
                                         digest::(0x0b 0x71 0x0e)) } }
-*/
 { ion:$1,            expect:{ identity:(update::(0x0b) update::(0x70) update::(0x24 0x69 0x6f 0x6e) update::(0x0e)
                                         digest::(0x0b 0x70 0x24 0x69 0x6f 0x6e 0x0e)) } }
 // skipping $2, as it can't be processed in this manner

--- a/Amazon.IonHashDotnet/Serializer.cs
+++ b/Amazon.IonHashDotnet/Serializer.cs
@@ -75,10 +75,13 @@ namespace Amazon.IonHashDotnet
             this.BeginMarker();
 
             dynamic ionValueValue = ionValue.CurrentIsNull ? null : ionValue.CurrentValue;
+
+            Boolean isZeroSymbol = (ionValue.CurrentType == IonType.Symbol && ionValueValue.Text == null && ionValueValue.Sid == 0) ? true: false;
+
             byte[] scalarBytes = this.GetBytes(ionValue.CurrentType, ionValueValue, ionValue.CurrentIsNull);
             (byte tq, byte[] representation) = this.ScalarOrNullSplitParts(
                 ionValue.CurrentType,
-                ionValue.CurrentIsNull,
+                isZeroSymbol,
                 scalarBytes);
 
             this.Update(new byte[] { tq });
@@ -277,7 +280,7 @@ namespace Amazon.IonHashDotnet
             return 0;
         }
 
-        private (byte, byte[]) ScalarOrNullSplitParts(IonType type, bool isNull, byte[] bytes)
+        private (byte, byte[]) ScalarOrNullSplitParts(IonType type, Boolean isZeroSymbol, byte[] bytes)
         {
             int offset = this.GetLengthLength(bytes) + 1;
 
@@ -299,9 +302,9 @@ namespace Amazon.IonHashDotnet
             {
                 // symbols are serialized as strings; use the correct TQ:
                 tq = 0x70;
-                if (isNull)
+                if (isZeroSymbol)
                 {
-                    tq |= 0x0F;
+                    tq = 0x71;
                 }
             }
 


### PR DESCRIPTION
Issue #, if available:
11 Symbol test is failing in IonHashTest.ion

Description of changes:
Currently the implementation is based on JS and zero symbols are not supported. Modified serializer logic to handle zero symbol like java impl

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.